### PR TITLE
Add utility and service tests

### DIFF
--- a/src/test/java/shop/ink3/auth/service/ReactiveServiceTest.java
+++ b/src/test/java/shop/ink3/auth/service/ReactiveServiceTest.java
@@ -1,0 +1,96 @@
+package shop.ink3.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import shop.ink3.auth.client.dooray.dto.DoorayMessageRequest;
+import shop.ink3.auth.client.dooray.service.DoorayMessageService;
+import shop.ink3.auth.client.dto.CommonResponse;
+import shop.ink3.auth.client.user.UserClient;
+import shop.ink3.auth.client.user.dto.UserStatus;
+import shop.ink3.auth.client.user.dto.UserStatusResponse;
+import shop.ink3.auth.dto.SendReactiveCodeRequest;
+import shop.ink3.auth.dto.VerifyReactiveCodeRequest;
+import shop.ink3.auth.exception.InvalidReactiveCodeException;
+import shop.ink3.auth.exception.InvalidUserStateException;
+import shop.ink3.auth.repository.ReactiveCodeRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ReactiveServiceTest {
+    @Mock
+    ReactiveCodeRepository reactiveCodeRepository;
+    @Mock
+    DoorayMessageService doorayMessageService;
+    @Mock
+    UserClient userClient;
+
+    @InjectMocks
+    ReactiveService reactiveService;
+
+    @Test
+    void sendReactiveCode() {
+        SendReactiveCodeRequest request = new SendReactiveCodeRequest("user");
+        when(userClient.getUserStatus("user"))
+                .thenReturn(CommonResponse.success(new UserStatusResponse(UserStatus.DORMANT)));
+
+        reactiveService.sendReactiveCode(request);
+
+        ArgumentCaptor<String> codeCaptor = ArgumentCaptor.forClass(String.class);
+        verify(reactiveCodeRepository).saveReactiveCode(eq("user"), codeCaptor.capture());
+        String code = codeCaptor.getValue();
+        assertThat(code).matches("\\d{6}");
+
+        ArgumentCaptor<DoorayMessageRequest> requestCaptor = ArgumentCaptor.forClass(DoorayMessageRequest.class);
+        verify(doorayMessageService).sendMessage(requestCaptor.capture());
+        assertThat(requestCaptor.getValue().attachments().get(0).text()).isEqualTo(code);
+    }
+
+    @Test
+    void sendReactiveCodeWithInvalidState() {
+        SendReactiveCodeRequest request = new SendReactiveCodeRequest("user");
+        when(userClient.getUserStatus("user"))
+                .thenReturn(CommonResponse.success(new UserStatusResponse(UserStatus.ACTIVE)));
+
+        assertThatThrownBy(() -> reactiveService.sendReactiveCode(request))
+                .isInstanceOf(InvalidUserStateException.class);
+    }
+
+    @Test
+    void reactivateUser() {
+        VerifyReactiveCodeRequest request = new VerifyReactiveCodeRequest("user", "123456");
+        when(reactiveCodeRepository.getReactiveCode("user")).thenReturn("123456");
+
+        reactiveService.reactivateUser(request);
+
+        verify(userClient).activateUser("user");
+        verify(reactiveCodeRepository).deleteReactiveCode("user");
+    }
+
+    @Test
+    void reactivateUserWithInvalidCode() {
+        VerifyReactiveCodeRequest request = new VerifyReactiveCodeRequest("user", "000000");
+        when(reactiveCodeRepository.getReactiveCode("user")).thenReturn("123456");
+
+        assertThatThrownBy(() -> reactiveService.reactivateUser(request))
+                .isInstanceOf(InvalidReactiveCodeException.class);
+    }
+
+    @Test
+    void reactivateUserWithCodeNotFound() {
+        VerifyReactiveCodeRequest request = new VerifyReactiveCodeRequest("user", "000000");
+        when(reactiveCodeRepository.getReactiveCode("user")).thenReturn(null);
+
+        assertThatThrownBy(() -> reactiveService.reactivateUser(request))
+                .isInstanceOf(InvalidReactiveCodeException.class);
+    }
+}

--- a/src/test/java/shop/ink3/auth/util/CookieUtilTest.java
+++ b/src/test/java/shop/ink3/auth/util/CookieUtilTest.java
@@ -1,0 +1,33 @@
+package shop.ink3.auth.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletResponse;
+import shop.ink3.auth.dto.JwtToken;
+
+class CookieUtilTest {
+    @Test
+    void setTokenCookiesAddsAccessAndRefreshCookie() {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        long now = System.currentTimeMillis();
+        JwtToken accessToken = new JwtToken("access", now + 60_000);
+        JwtToken refreshToken = new JwtToken("refresh", now + 120_000);
+
+        CookieUtil.setTokenCookies(response, accessToken, refreshToken);
+
+        assertThat(response.getHeaders(HttpHeaders.SET_COOKIE)).hasSize(2);
+        String accessCookie = response.getHeaders(HttpHeaders.SET_COOKIE).get(0);
+        String refreshCookie = response.getHeaders(HttpHeaders.SET_COOKIE).get(1);
+
+        assertThat(accessCookie).contains("accessToken=access");
+        assertThat(accessCookie).contains("HttpOnly");
+        assertThat(accessCookie).contains("Secure");
+        assertThat(accessCookie).contains("Path=/");
+        assertThat(accessCookie).contains("SameSite=Lax");
+
+        assertThat(refreshCookie).contains("refreshToken=refresh");
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for setting cookies in `CookieUtil`
- cover reactivation workflow in `ReactiveService`

## Testing
- `./mvnw -q test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6850e01279a08324a7e58c657ba5d45e